### PR TITLE
forbid bad protobuf version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - packaging
     - pandas >=0.21.0
     - pillow >=6.2.0
-    - protobuf >=3.6.0
+    - protobuf >=3.6.0, !=3.11
     - pyarrow
     - pydeck >=0.1.dev5
     - python >=3.6


### PR DESCRIPTION
# Proposed solution for https://github.com/conda-forge/streamlit-feedstock/issues/15 

Should fix issue described here: https://github.com/conda-forge/streamlit-feedstock/issues/15 



protobuf version 3.11 is incompatible, see https://github.com/streamlit/streamlit/issues/2234

* forbid the bad version

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
This is my first public pull request, I don't think any of the checklist items apply.