### PR TITLE
Unpin Pandas version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: f13f7463d53fb866a1d07dccfacb60333c56dc9f34b001f310475beee71a08a5
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -34,7 +34,7 @@ requirements:
     - gitpython
     - numpy
     - packaging
-    - pandas >=0.21.0, <1.3.0
+    - pandas >=0.21.0
     - pillow >=6.2.0
     - protobuf >=3.6.0, !=3.11
     - pyarrow


### PR DESCRIPTION
The upstream already fixed on Pandas 1.3.0.

See:
https://github.com/streamlit/streamlit/commit/34a4f4979638f8774238c9be482b1dcfe815e37f

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist:
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I'm not familiar with the conda-smithy and maybe someone could help me fix this package. Thanks.